### PR TITLE
Fix: show OS Templates for selected Location across Admin and Client Area (servers[] pivot support)

### DIFF
--- a/includes/modules/Hosting/easydcim/app/UI/admin/productConfig/sections/ClientAreaFeatures.php
+++ b/includes/modules/Hosting/easydcim/app/UI/admin/productConfig/sections/ClientAreaFeatures.php
@@ -16,8 +16,32 @@ class ClientAreaFeatures
         $this->api = $api;
     }
 
-    public function getOsTemplates(){
-        return $this->api->os->getTemplateList();
+    public function getOsTemplates($locationId = null){
+        try {
+            $templateList = $this->api->os->getTemplateList();
+            if (!empty($locationId)) {
+                $provisioningServerId = $this->api->os->getOsTemplateForLocation($locationId)->id;
+
+                $templateList = array_values(array_filter($templateList, function($tpl) use ($provisioningServerId) {
+                    // Match direct server_id
+                    if (isset($tpl->server_id) && (int)$tpl->server_id === (int)$provisioningServerId) {
+                        return true;
+                    }
+                    // Or any related server in "servers" array (pivot)
+                    if (isset($tpl->servers) && is_array($tpl->servers)) {
+                        foreach ($tpl->servers as $srv) {
+                            if (isset($srv->id) && (int)$srv->id === (int)$provisioningServerId) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }));
+            }
+            return $templateList;
+        } catch (\Exception $ex) {
+            return [];
+        }
     }
 
     public function getFields(){

--- a/includes/modules/Hosting/easydcim/app/UI/admin/productConfig/sections/DefaultOptions.php
+++ b/includes/modules/Hosting/easydcim/app/UI/admin/productConfig/sections/DefaultOptions.php
@@ -37,12 +37,21 @@ class DefaultOptions
             {
                 $provisioningServerId = $this->api->os->getOsTemplateForLocation($locationId)->id;
 
-                foreach ($templateList as $key=>$value) {
-                    if ($value->server_id != $provisioningServerId)
-                    {
-                        unset($templateList[$key]);
+                $templateList = array_values(array_filter($templateList, function($tpl) use ($provisioningServerId) {
+                    // Match direct server_id
+                    if (isset($tpl->server_id) && (int)$tpl->server_id === (int)$provisioningServerId) {
+                        return true;
                     }
-                }
+                    // Or match any of the related servers in "servers" array
+                    if (isset($tpl->servers) && is_array($tpl->servers)) {
+                        foreach ($tpl->servers as $srv) {
+                            if (isset($srv->id) && (int)$srv->id === (int)$provisioningServerId) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }));
                 return $templateList;
             }
             return [];


### PR DESCRIPTION
Summary

- Previously, OS Templates were filtered only by template.server_id matching the provisioning server for the selected Location. Templates linked via the API’s servers[] pivot (multi-server association) were ignored.
- In Client Area Features, getOsTemplates() returned the full unfiltered list, not taking Location into account.
- This caused empty lists when provisioning server ≠ template.server_id, even if the provisioning server was present in servers[].

What changed

- Admin product config (DefaultOptions::getTemplateList):

  - Filter now includes templates when either:

    - template.server_id == provisioningServerId, or
    - any(template.servers[].id == provisioningServerId)

  - Reindexed the array via array_values to return a clean list.

- Client Area Features (ClientAreaFeatures::getOsTemplates):

  - Method now accepts optional $locationId.
  - Applies the same servers[]-aware filtering when $locationId is provided; otherwise returns full list (backward compatible).

Files changed

- includes/modules/Hosting/easydcim/app/UI/admin/productConfig/sections/DefaultOptions.php
  - Method: getTemplateList($locationId)
- includes/modules/Hosting/easydcim/app/UI/admin/productConfig/sections/ClientAreaFeatures.php
  - Method: getOsTemplates($locationId = null)

Why this is safe

- Accounts for the official EasyDCIM API response where templates can be linked to multiple servers via servers[].
- Backward compatible for callers that do not pass $locationId (ClientAreaFeatures).
- The Admin path already passes Location and now correctly includes pivot links.

How to test

1. API verification:

   - Get provisioning server for a Location: curl -s -H 'apikey: {API_KEY}' '{BASE_URL}/api/v2/os/server/location/{LOCATION_ID}' | jq '.' Note .result.id as SERVER_ID.
   - Check filtered templates as the module expects: curl -s -H 'apikey: {API_KEY}' '{BASE_URL}/api/v2/os/template'\
     | jq --arg sid "$SERVER_ID" ' .result | map( select( (.server_id == ($sid|tonumber)) or ((.servers // []) | any(.id == ($sid|tonumber))) ) )'

2. HostBill Admin:

   - Open product config for EasyDCIM module.

   - Change Location to one whose provisioning server differs from template.server_id but exists in template.servers[].

   - Verify:

     - “OS Template” select is populated.
     - “Client Area Features → OS Templates” (caTemplates) is populated consistently for the same Location.

Notes

- Endpoints involved:

  - GET {BASE_URL}/api/v2/os/server/location/{LOCATION_ID}
  - GET {BASE_URL}/api/v2/os/template

- No breaking changes expected; behavior is broadened to include valid templates linked via servers[].
